### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ This Atom package provides a [Linter](https://atom.io/packages/linter) for MATLA
 
 1. Install the Linter package, following the instructions on [this page](https://atom.io/packages/linter).
 2. `apm install linter-matlab`
-3. If `mlint` is not already in your PATH, you will need to set the `mlintDir` setting to point to the directory containing `mlint`. As noticed by [@hyiltiz](https://github.com/hyiltiz), this currently does not work with symbolic links.
+3. If `mlint` is not already in your PATH, you will need to set the `mlintDir` setting to point to the directory containing `mlint`. As noticed by [@hyiltiz](https://github.com/hyiltiz), this currently does not work with symbolic links. For example, on Linux, the path for MATLAB R2015b is `/usr/local/MATLAB/R2015b/bin/glnxa64`.


### PR DESCRIPTION
Add an example of a path for Linux for MATLAB R2015b. It took me a while to find the correct path, so I figure this is possibly helpful to people who have trouble finding it.
